### PR TITLE
Add Restaurants e2e tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/services/wiremock/WiremockServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/wiremock/WiremockServiceImpl.java
@@ -21,7 +21,8 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 /**
  * This is a service for mocking authentication using wiremock
  * 
- * This class relies on property values. For hints on testing, see: <a href="https://www.baeldung.com/spring-boot-testing-configurationproperties">https://www.baeldung.com/spring-boot-testing-configurationproperties</a>
+ * This class relies on property values. For hints on testing, see: <a href=
+ * "https://www.baeldung.com/spring-boot-testing-configurationproperties">https://www.baeldung.com/spring-boot-testing-configurationproperties</a>
  * 
  */
 @Slf4j
@@ -34,6 +35,7 @@ public class WiremockServiceImpl extends WiremockService {
 
   /**
    * This method returns the wiremockServer
+   * 
    * @return the wiremockServer
    */
   public WireMockServer getWiremockServer() {
@@ -42,9 +44,10 @@ public class WiremockServiceImpl extends WiremockService {
 
   /**
    * This method sets up the necessary mocks for authentication
+   * 
    * @param s in an instance of a WireMockServer or WireMockExtension
    */
-  public static void setupOauthMocks(Stubbing s) {
+  public static void setupOauthMocks(Stubbing s, boolean isAdmin) {
 
     s.stubFor(get(urlPathMatching("/oauth/authorize.*"))
         .willReturn(aResponse()
@@ -61,25 +64,50 @@ public class WiremockServiceImpl extends WiremockService {
             okJson(
                 "{\"access_token\":\"{{randomValue length=20 type='ALPHANUMERIC'}}\",\"token_type\": \"Bearer\",\"expires_in\":\"3600\",\"scope\":\"https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email openid\"}")));
 
-    s.stubFor(get(urlPathMatching("/userinfo"))
-        .willReturn(aResponse()
-            .withStatus(200)
-            .withHeader("Content-Type", "application/json")
-            .withBody("{\"sub\":\"107126842018026740288\"" +
-                ",\"name\":\"Chris Gaucho\"" +
-                ",\"given_name\":\"Chris\"" +
-                ",\"family_name\":\"Gaucho\"" +
-                ", \"picture\":\"https://lh3.googleusercontent.com/a/ACg8ocJpOe2SqIpirdIMx7KTj1W4OQ45t6FwpUo40K2V2JON=s96-c\"" +
-                ", \"email\":\"cgaucho@ucsb.edu\"" +
-                ",\"email_verified\":true" +
-                ",\"locale\":\"en\"" +
-                ",\"hd\":\"ucsb.edu\"" +
-                "}")));
+    if (isAdmin) {
+      s.stubFor(get(urlPathMatching("/userinfo"))
+          .willReturn(aResponse()
+              .withStatus(200)
+              .withHeader("Content-Type", "application/json")
+              .withBody(
+                  """
+                      {
+                        "sub": "107126842018026740288",
+                        "name": "Admin GaucSho",
+                        "given_name": "Admin",
+                        "family_name": "Gaucho",
+                        "picture": "https://lh3.googleusercontent.com/a/ACg8ocJpOe2SqIpirdIMx7KTj1W4OQ45t6FwpUo40K2V2JON=s96-c",
+                        "email": "admingaucho@ucsb.edu",
+                        "email_verified": true,
+                        "locale": "en",
+                        "hd": "ucsb.edu"
+                      }
+                      """)));
+    } else {
+      s.stubFor(get(urlPathMatching("/userinfo"))
+          .willReturn(aResponse()
+              .withStatus(200)
+              .withHeader("Content-Type", "application/json")
+              .withBody(
+                  """
+                      {
+                        "sub": "107126842018026740288",
+                        "name": "Chris Gaucho",
+                        "given_name": "Chris",
+                        "family_name": "Gaucho",
+                        "picture": "https://lh3.googleusercontent.com/a/ACg8ocJpOe2SqIpirdIMx7KTj1W4OQ45t6FwpUo40K2V2JON=s96-c",
+                        "email": "cgaucho@ucsb.edu",
+                        "email_verified": true,
+                        "locale": "en",
+                        "hd": "ucsb.edu"
+                      }
+                      """)));
+    }
 
   }
 
   /**
-   * This method initializes the WireMockServer 
+   * This method initializes the WireMockServer
    */
   public void init() {
     log.info("WiremockServiceImpl.init() called");
@@ -88,7 +116,7 @@ public class WiremockServiceImpl extends WiremockService {
         .port(8090) // No-args constructor will start on port
         .extensions(new ResponseTemplateTransformer(true)));
 
-    setupOauthMocks(wireMockServer);
+    setupOauthMocks(wireMockServer, true);
 
     wireMockServer.start();
 

--- a/src/main/resources/application-integration.properties
+++ b/src/main/resources/application-integration.properties
@@ -1,6 +1,6 @@
 logging.level.sql=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
-spring.datasource.url=jdbc:h2:file:./target/db-development
+spring.datasource.url=jdbc:h2:mem:${random.uuid}
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
@@ -26,3 +26,7 @@ spring.security.oauth2.client.provider.my-oauth-provider.user-info-authenticatio
 spring.security.oauth2.client.provider.my-oauth-provider.user-name-attribute=sub
 
 app.oauth.login=${OAUTH_LOGIN:${env.OAUTH_LOGIN:/oauth2/authorization/my-oauth-provider}}
+
+app.admin.emails=${ADMIN_EMAILS:${env.ADMIN_EMAILS:admingaucho@ucsb.edu}}
+
+app.playwright.headless=${HEADLESS:${env.HEADLESS:true}}

--- a/src/main/resources/application-wiremock.properties
+++ b/src/main/resources/application-wiremock.properties
@@ -26,3 +26,5 @@ spring.security.oauth2.client.provider.my-oauth-provider.user-info-authenticatio
 spring.security.oauth2.client.provider.my-oauth-provider.user-name-attribute=sub
 
 app.oauth.login=${OAUTH_LOGIN:${env.OAUTH_LOGIN:/oauth2/authorization/my-oauth-provider}}
+
+app.admin.emails=${ADMIN_EMAILS:${env.ADMIN_EMAILS:admingaucho@ucsb.edu}}

--- a/src/test/java/edu/ucsb/cs156/example/web/ITExample.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/ITExample.java
@@ -20,7 +20,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 public class ITExample {
     @Test
-    public void testTest() throws Exception {
+    public void example_test() throws Exception {
         assertTrue(true);
     }
 }

--- a/src/test/java/edu/ucsb/cs156/example/web/ITHomePage.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/ITHomePage.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
@@ -14,6 +15,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
@@ -21,7 +23,10 @@ import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertTha
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ActiveProfiles("integration")
-class ITHomePage {
+public class ITHomePage {
+    @Value("${app.playwright.headless:true}")
+    private boolean runHeadless;
+
     @LocalServerPort
     private int port;
 
@@ -30,7 +35,8 @@ class ITHomePage {
 
     @BeforeEach
     public void setup() {
-        browser = Playwright.create().chromium().launch();
+        browser = Playwright.create().chromium().launch(new BrowserType.LaunchOptions().setHeadless(runHeadless));
+
         BrowserContext context = browser.newContext();
         page = context.newPage();
     }
@@ -41,11 +47,12 @@ class ITHomePage {
     }
 
     @Test
-    public void testGreeting() throws Exception {
+    public void home_page_shows_greeting() throws Exception {
         String url = String.format("http://localhost:%d/", port);
         page.navigate(url);
 
-        assertThat(page.getByText("This is a webapp containing a bunch of different Spring Boot/React examples.")).isVisible();
+        assertThat(page.getByText("This is a webapp containing a bunch of different Spring Boot/React examples."))
+                .isVisible();
     }
 
 }

--- a/src/test/java/edu/ucsb/cs156/example/web/ITRestaurant.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/ITRestaurant.java
@@ -1,0 +1,145 @@
+package edu.ucsb.cs156.example.web;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+
+import com.microsoft.playwright.Playwright;
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import edu.ucsb.cs156.example.services.wiremock.WiremockServiceImpl;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@ActiveProfiles("integration")
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class ITRestaurant {
+    @Value("${app.playwright.headless:true}")
+    private boolean runHeadless;
+
+    @LocalServerPort
+    private int port;
+
+    private Browser browser;
+    private Page page;
+
+    private static WireMockServer wireMockServer;
+
+    @BeforeAll
+    public static void setupWireMock() {
+        wireMockServer = new WireMockServer(options()
+                .port(8090)
+                .extensions(new ResponseTemplateTransformer(true)));
+
+        wireMockServer.start();
+    }
+
+    public void setupAdmin() {
+        WiremockServiceImpl.setupOauthMocks(wireMockServer, true);
+
+        browser = Playwright.create().chromium().launch(new BrowserType.LaunchOptions().setHeadless(runHeadless));
+
+        BrowserContext context = browser.newContext();
+        page = context.newPage();
+
+        String url = String.format("http://localhost:%d/oauth2/authorization/my-oauth-provider", port);
+        page.navigate(url);
+
+        page.locator("#username").fill("admingaucho@ucsb.edu");
+        page.locator("#password").fill("password");
+        page.locator("#submit").click();
+
+        assertThat(page.getByText("Log Out")).isVisible();
+        assertThat(page.getByText("Welcome, admingaucho@ucsb.edu")).isVisible();
+
+        url = String.format("http://localhost:%d/", port);
+        page.navigate(url);
+    }
+
+    public void setupRegularUser() {
+        WiremockServiceImpl.setupOauthMocks(wireMockServer, false);
+
+        browser = Playwright.create().chromium().launch(new BrowserType.LaunchOptions().setHeadless(runHeadless));
+
+        BrowserContext context = browser.newContext();
+        page = context.newPage();
+
+        String url = String.format("http://localhost:%d/oauth2/authorization/my-oauth-provider", port);
+        page.navigate(url);
+
+        page.locator("#username").fill("cgaucho@ucsb.edu");
+        page.locator("#password").fill("password");
+        page.locator("#submit").click();
+
+        assertThat(page.getByText("Log Out")).isVisible();
+        assertThat(page.getByText("Welcome, cgaucho@ucsb.edu")).isVisible();
+
+        url = String.format("http://localhost:%d/", port);
+        page.navigate(url);
+    }
+
+    @AfterEach
+    public void teardown() {
+        browser.close();
+    }
+
+    @AfterAll
+    public static void teardownWiremock() {
+        wireMockServer.stop();
+    }
+
+    @Test
+    public void admin_user_can_create_edit_delete_restaurant() throws Exception {
+        setupAdmin();
+
+        page.getByText("Restaurants").click();
+
+        page.getByText("Create Restaurant").click();
+        assertThat(page.getByText("Create New Restaurant")).isVisible();
+        page.getByTestId("RestaurantForm-name").fill("Freebirds");
+        page.getByTestId("RestaurantForm-description").fill("Build your own burrito chain");
+        page.getByTestId("RestaurantForm-submit").click();
+
+        assertThat(page.getByTestId("RestaurantTable-cell-row-0-col-description"))
+                .hasText("Build your own burrito chain");
+
+        page.getByTestId("RestaurantTable-cell-row-0-col-Edit-button").click();
+        assertThat(page.getByText("Edit Restaurant")).isVisible();
+        page.getByTestId("RestaurantForm-description").fill("THE BEST");
+        page.getByTestId("RestaurantForm-submit").click();
+
+        assertThat(page.getByTestId("RestaurantTable-cell-row-0-col-description")).hasText("THE BEST");
+
+        page.getByTestId("RestaurantTable-cell-row-0-col-Delete-button").click();
+
+        assertThat(page.getByTestId("RestaurantTable-cell-row-0-col-name")).not().isVisible();
+    }
+
+    @Test
+    public void regular_user_cannot_create_restaurant() throws Exception {
+        setupRegularUser();
+
+        page.getByText("Restaurants").click();
+
+        assertThat(page.getByText("Create Restaurant")).not().isVisible();
+        assertThat(page.getByTestId("RestaurantTable-cell-row-0-col-name")).not().isVisible();
+    }
+}


### PR DESCRIPTION
In this PR:

- E2E tests for `Restaurants` which test an admins ability to create, edit, and delete entries through the frontend and a regular user's ability to view the index page.
- The combination of the `@DirtiesContext` annotation and `spring.datasource.url=jdbc:h2:mem:${random.uuid}` which allows for tests to run with independent databases.
- `HEADLESS` env variable (default: true) which allows the developer to decide whether or not to run Playwright tests headless or not, removing the previously commented code.
- `isAdmin` boolean for setupOauthMocks which allows to setup the mocks to login either with an admin email or regular user