### PR TITLE
Fix admin email bug in tests

### DIFF
--- a/src/main/resources/application-integration.properties
+++ b/src/main/resources/application-integration.properties
@@ -27,6 +27,6 @@ spring.security.oauth2.client.provider.my-oauth-provider.user-name-attribute=sub
 
 app.oauth.login=${OAUTH_LOGIN:${env.OAUTH_LOGIN:/oauth2/authorization/my-oauth-provider}}
 
-app.admin.emails=${ADMIN_EMAILS:${env.ADMIN_EMAILS:admingaucho@ucsb.edu}}
+app.admin.emails=admingaucho@ucsb.edu
 
 app.playwright.headless=${HEADLESS:${env.HEADLESS:true}}

--- a/src/main/resources/application-wiremock.properties
+++ b/src/main/resources/application-wiremock.properties
@@ -27,4 +27,4 @@ spring.security.oauth2.client.provider.my-oauth-provider.user-name-attribute=sub
 
 app.oauth.login=${OAUTH_LOGIN:${env.OAUTH_LOGIN:/oauth2/authorization/my-oauth-provider}}
 
-app.admin.emails=${ADMIN_EMAILS:${env.ADMIN_EMAILS:admingaucho@ucsb.edu}}
+app.admin.emails=admingaucho@ucsb.edu


### PR DESCRIPTION
This PR fixes a bug/oversight where when you have your `.env` setup with admin emails, it overrides the `admingaucho@ucsb.edu` in both `application-integration.properties` and `application-wiremock.properties`, making it so that the mocked user is unable to gain admin access.